### PR TITLE
Use TOML v0.4.0 escape sequences.

### DIFF
--- a/Syntaxes/TOML.tmLanguage
+++ b/Syntaxes/TOML.tmLanguage
@@ -198,9 +198,15 @@
 					<array>
 						<dict>
 							<key>match</key>
-							<string>\\([tnr"\\]|x\h\h)</string>
+							<string>\\([btnfr"\\]|u\h{4}|U\h{8})</string>
 							<key>name</key>
 							<string>constant.character.escape.toml</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>\\[^btnfr"\\]</string>
+							<key>name</key>
+							<string>invalid.illegal.not-allowed-here.toml</string>
 						</dict>
 					</array>
 				</dict>
@@ -231,9 +237,15 @@
 					<array>
 						<dict>
 							<key>match</key>
-							<string>\\([tnr"\\]|x\h\h)</string>
+							<string>\\([btnfr"\\]|u\h{4}|U\h{8})</string>
 							<key>name</key>
 							<string>constant.character.escape.toml</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>\\[^btnfr"\\]</string>
+							<key>name</key>
+							<string>invalid.illegal.not-allowed-here.toml</string>
 						</dict>
 					</array>
 				</dict>

--- a/Syntaxes/TOML.tmLanguage
+++ b/Syntaxes/TOML.tmLanguage
@@ -204,9 +204,9 @@
 						</dict>
 						<dict>
 							<key>match</key>
-							<string>\\[^btnfr"\\]</string>
+							<string>\\[^btnfr"\\\n]</string>
 							<key>name</key>
-							<string>invalid.illegal.not-allowed-here.toml</string>
+							<string>invalid.illegal.triple.double.escape.toml</string>
 						</dict>
 					</array>
 				</dict>
@@ -245,7 +245,7 @@
 							<key>match</key>
 							<string>\\[^btnfr"\\]</string>
 							<key>name</key>
-							<string>invalid.illegal.not-allowed-here.toml</string>
+							<string>invalid.illegal.double.escape.toml</string>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
TOML v0.4.0 defines the following escape sequences:

```
\b         - backspace       (U+0008)
\t         - tab             (U+0009)
\n         - linefeed        (U+000A)
\f         - form feed       (U+000C)
\r         - carriage return (U+000D)
\"         - quote           (U+0022)
\\         - backslash       (U+005C)
\uXXXX     - unicode         (U+XXXX)
\UXXXXXXXX - unicode         (U+XXXXXXXX)
```
