### PR TITLE
Allow underscores in integers/floats per v0.4.0.

### DIFF
--- a/Syntaxes/TOML.tmLanguage
+++ b/Syntaxes/TOML.tmLanguage
@@ -316,15 +316,9 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\G[+-]?[0-9]+\.[0-9]+([eE][+-]?(0|[1-9][0-9]*))?</string>
+					<string>\G([+-]?(0|([1-9](([0-9]|_[0-9])+)?)))(\.([0-9](([0-9]|_[0-9])+)?))?([eE]([+-]?(0|([1-9](([0-9]|_[0-9])+)?))))?</string>
 					<key>name</key>
-					<string>constant.numeric.float.toml</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\G[+-]?(0|[1-9][0-9]*)([eE][+-]?(0|[1-9][0-9]*))?</string>
-					<key>name</key>
-					<string>constant.numeric.integer.toml</string>
+					<string>constant.numeric.number.toml</string>
 				</dict>
 				<dict>
 					<key>begin</key>


### PR DESCRIPTION
From TOML v0.4.0:

> For large numbers, you may use underscores to enhance readability. Each underscore must be surrounded by at least one digit.

and

> Similar to integers, you may use underscores to enhance readability. Each underscore must be surrounded by at least one digit.

This change unifies integer and float into a single `number` definition, which simplifies the parsing, but makes it impossible to distinguish floats from integers.