### PR TITLE
Allow quoted keys.

### DIFF
--- a/Syntaxes/TOML.tmLanguage
+++ b/Syntaxes/TOML.tmLanguage
@@ -26,6 +26,10 @@
 		</dict>
 		<dict>
 			<key>include</key>
+			<string>#quoted_key_pair</string>
+		</dict>
+		<dict>
+			<key>include</key>
 			<string>#invalid</string>
 		</dict>
 	</array>
@@ -143,15 +147,52 @@
 		<key>key_pair</key>
 		<dict>
 			<key>begin</key>
-			<string>(\S+)\s*(=)\s*</string>
+			<string>([A-Za-z0-9_-]+)\s*(=)\s*</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>support.constant.toml</string>
+					<string>variable.other.key.toml</string>
 				</dict>
 				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.key-value.toml</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?&lt;=\S)(?&lt;!=)|$</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#primatives</string>
+				</dict>
+			</array>
+		</dict>
+		<key>quoted_key_pair</key>
+		<dict>
+			<key>begin</key>
+			<string>((")(.*)("))\s*(=)\s*</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>variable.other.key.toml</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.variable.begin.toml</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.variable.end.toml</string>
+				</dict>
+				<key>5</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.separator.key-value.toml</string>


### PR DESCRIPTION
TOML v0.4.0 states:

> Keys may be either bare or quoted. Bare keys may only contain letters, numbers, underscores, and dashes (`A-Za-z0-9_-`). Quoted keys follow the exact same rules as basic strings and allow you to use a much broader set of key names. Best practice is to use bare keys except when absolutely necessary.

This PR takes a pretty simple approach to adding this feature. It allows anything at all in quoted keys (including bare `"`s. It also doesn't do any detection of escape sequences or error checking for invalid escape sequences, as I haven't figured out the right way to do that in TextMate grammars yet.