### PR TITLE
Allow literal strings and plus-prefixed numbers in arrays.

### DIFF
--- a/Syntaxes/TOML.tmLanguage
+++ b/Syntaxes/TOML.tmLanguage
@@ -353,7 +353,7 @@
 					<array>
 						<dict>
 							<key>begin</key>
-							<string>(?="|-?[0-9]|true|false|\[)</string>
+							<string>(?=["'']|[+-]?[0-9]|true|false|\[)</string>
 							<key>end</key>
 							<string>,|(?=])</string>
 							<key>endCaptures</key>


### PR DESCRIPTION
The array element regex was rejecting elements that started with a `+` or a single quote.