### PR TITLE
Add inline tables per TOML v0.4.0.

### DIFF
--- a/Syntaxes/TOML.tmLanguage
+++ b/Syntaxes/TOML.tmLanguage
@@ -353,7 +353,7 @@
 					<array>
 						<dict>
 							<key>begin</key>
-							<string>(?="|-?[0-9]|true|false|\[)</string>
+							<string>(?="|-?[0-9]|true|false|\[|\{)</string>
 							<key>end</key>
 							<string>,|(?=])</string>
 							<key>endCaptures</key>
@@ -387,6 +387,62 @@
 						<dict>
 							<key>include</key>
 							<string>#invalid</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>\G\{</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.inline-table.begin.toml</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\}</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.inline-table.end.toml</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.inline-table.toml</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>begin</key>
+							<string>(?=\S)</string>
+							<key>end</key>
+							<string>,|(?=})</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.separator.inline-table.toml</string>
+								</dict>
+							</dict>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#key_pair</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#quoted_key_pair</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#comments</string>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
Simple support for inline tables:

> Inline tables provide a more compact syntax for expressing tables. They are especially useful for grouped data that can otherwise quickly become verbose. Inline tables are enclosed in curly braces `{` and `}`. Within the braces, zero or more comma separated key/value pairs may appear. Key/value pairs take the same form as key/value pairs in standard tables. All value types are allowed, including inline tables.