### PR TITLE
Update syntax to TOML v1.0.0-rc.1

### DIFF
--- a/Syntaxes/TOML.tmLanguage
+++ b/Syntaxes/TOML.tmLanguage
@@ -172,7 +172,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>((")(.*)("))\s*(=)\s*</string>
+					<string>((")(.*?)("))\s*(=)\s*</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>
@@ -388,7 +388,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>"""</string>
+					<string>"{3,5}</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>0</key>
@@ -466,7 +466,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>'''</string>
+					<string>'{3,5}</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>0</key>
@@ -511,7 +511,7 @@
 						-
 						(?!00|3[2-9])[0-3][0-9]
 						(
-							[Tt]
+							[Tt ]
 							(?!2[5-9])[0-2][0-9]
 							:
 							[0-5][0-9]
@@ -526,6 +526,19 @@
 					</string>
 					<key>name</key>
 					<string>constant.other.date.toml</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\G(?x)
+						(?!2[5-9])[0-2][0-9]
+						:
+						[0-5][0-9]
+						:
+						(?!6[1-9])[0-6][0-9]
+						(\.[0-9]+)?
+					</string>
+					<key>name</key>
+					<string>constant.other.time.toml</string>
 				</dict>
 				<dict>
 					<key>match</key>
@@ -575,7 +588,7 @@
 						)?
 						(
 						    [eE]
-						    ([+-]?(0|([1-9](([0-9]|_[0-9])+)?)))
+						    ([+-]?[0-9](([0-9]|_[0-9])+)?)
 						)?
 					</string>
 					<key>name</key>


### PR DESCRIPTION
Correctly highlight quoted key/value pairs if the value starts with an equals sign.
Don't mark datetimes with space instead of T as invalid.
Don't mark local time as invalid.
Allow leading zeros in float exponent.
Accept multi-line strings with inner quotes at the end. 


Closes #11 
Closes #12 
Closes #13

With these changes all valid TOML documents from [the specification](https://github.com/toml-lang/toml/blob/v1.0.0-rc.1/README.md) are correctly highlighted i. e. nothing is marked as illegal in these correct documents.

You can use the following document to test the changes on <https://github-lightshow.herokuapp.com>.

```toml
# Issue #13
flt1 = 5e+22
flt2 = 5e+022
flt3 = 5e022

# Issue #12
odt4 = 1979-05-27 07:32:00Z
lt1 = 07:32:00
lt2 = 00:32:00.999999

# Issue #11
[ok]
'key1' = 'value'
'key2' = "value"
"key3" = 'value'
"key4" = "value"
"key4b" = """value"""

[strange]
'key1' = '=value'
'key2' = "=value"
"key3" = '=value'
"key4" = "=value"  # warning
"key4b" = """=value"""  # warning
"key4c" = """v=v"""

"foo\"bar" = 0 # Additional test

# From toml-lang/toml README

str7 = """"This," she said, "is just a pointless statement.""""
str7 = ''''This," she said, 'is just a pointless statement.''''
```